### PR TITLE
Make discordbot work again... again!

### DIFF
--- a/discord_bot/config.json.example
+++ b/discord_bot/config.json.example
@@ -3,5 +3,8 @@
     "token": "",
     "guild": "",
     "channel": ""
+  },
+  "server": {
+    "port": "37405"
   }
 }

--- a/discord_bot/index.js
+++ b/discord_bot/index.js
@@ -4,7 +4,7 @@ const {log,error} = console;
 const http = require('http');
 const fs = require('fs');
 
-const PORT = 37405; //unused port and since now the OFFICIAL ttt_discord_bot port ;)
+const PORT = config.server.port; //unused port and since now the OFFICIAL ttt_discord_bot port ;)
 
 var guild, channel;
 
@@ -38,7 +38,7 @@ setMemberMutedByBot = (member,set=true) => muted[member] = set;
 get['connect'] = (params,ret) => {
 	let tag_utf8 = params.tag.split(" ");
 	let tag = "";
-	
+
 	tag_utf8.forEach(function(e) {
 		tag = tag+String.fromCharCode(e);
 	});
@@ -57,7 +57,7 @@ get['connect'] = (params,ret) => {
 			tag: found[0].user.tag,
 			id: found[0].id
 		});
-	}	
+	}
 };
 
 get['mute'] = (params,ret) => {
@@ -104,13 +104,13 @@ get['mute'] = (params,ret) => {
 		else {
 			ret();
 		}
-		
+
 	}else {
 		ret({
 			success: false,
 			err: 'member not found!' //TODO lua: remove from ids table + file
 		});
-	}	
+	}
 
 }
 
@@ -126,8 +126,7 @@ http.createServer((req,res)=>{
 	}else
 		res.end();
 }).listen({
-	port: PORT,
-	host: 'LOCALHOST'
+	port: PORT
 },()=>{
 	log('http interface is ready :)')
 });

--- a/gmod_addon/lua/autorun/shared.lua
+++ b/gmod_addon/lua/autorun/shared.lua
@@ -20,9 +20,10 @@ if (CLIENT) then
 	return
 end
 util.AddNetworkString("drawMute")
+CreateConVar("discordbot_host", "localhost", FCVAR_ARCHIVE, "Sets the node server address.")
+CreateConVar("discordbot_port", "37405", FCVAR_ARCHIVE, "Sets the node server port.")
+CreateConVar("discordbot_name", "TTT Discord Bot", FCVAR_ARCHIVE, "Sets the Plugin Prefix for helpermessages.") --The name which will be displayed in front of any Message
 
-PORT = 37405
-PREFIX = "[TTT Discord Bot] "
 FILEPATH = "ttt_discord_bot.dat"
 TRIES = 3
 
@@ -40,11 +41,12 @@ end
 
 
 function GET(req,params,cb,tries)
-	http.Fetch("http://localhost:"..PORT,function(res)
-		--print(res)
+	httpAdress = ("http://"..GetConVar("discordbot_host"):GetString()..":"..GetConVar("discordbot_port"):GetString())
+	http.Fetch(httpAdress,function(res)
+			--print(res)
 		cb(util.JSONToTable(res))
 	end,function(err)
-		print(PREFIX.."Request to bot failed. Is the bot running?")
+		print("["..GetConVar("discordbot_name"):GetString().."] ".."Request to bot failed. Is the bot running?")
 		print("Err: "..err)
 		if (!tries) then tries = TRIES end
 		if (tries != 0) then GET(req,params,cb, tries-1) end
@@ -77,12 +79,12 @@ function mute(ply)
 				if (res) then
 					--PrintTable(res)
 					if (res.success) then
-						ply:PrintMessage(HUD_PRINTCENTER,"You're muted in discord!")
+						ply:PrintMessage(HUD_PRINTCENTER,"["..GetConVar("discordbot_name"):GetString().."] ".."You're muted in discord!")
 						sendClientIconInfo(ply,true)
 						muted[ply] = true
 					end
 					if (res.error) then
-						print(PREFIX.."Error: "..res.err)
+						print("["..GetConVar("discordbot_name"):GetString().."] ".."Error: "..res.err)
 					end
 				end
 
@@ -98,13 +100,13 @@ function unmute(ply)
 				GET("mute",{mute=false,id=ids[ply:SteamID()]},function(res)
 					if (res.success) then
 						if (ply) then
-							ply:PrintMessage(HUD_PRINTCENTER,"You're no longer muted in discord!")
+							ply:PrintMessage(HUD_PRINTCENTER,"["..GetConVar("discordbot_name"):GetString().."] ".."You're no longer muted in discord!")
 						end
 						sendClientIconInfo(ply,false)
 						muted[ply] = false
 					end
 					if (res.error) then
-						print(PREFIX.."Error: "..res.err)
+						print("["..GetConVar("discordbot_name"):GetString().."] ".."Error: "..res.err)
 					end
 				end)
 			end
@@ -120,15 +122,15 @@ hook.Add("PlayerSay", "ttt_discord_bot_PlayerSay", function(ply,msg)
   if (string.sub(msg,1,9) != '!discord ') then return end
   tag = string.sub(msg,10)
   tag_utf8 = ""
-  
+
   for p, c in utf8.codes(tag) do
 	tag_utf8 = string.Trim(tag_utf8.." "..c)
   end
 	GET("connect",{tag=tag_utf8},function(res)
-		if (res.answer == 0) then ply:PrintMessage(HUD_PRINTTALK,"No guilde member with a discord tag like '"..tag.."' found.") end
-		if (res.answer == 1) then ply:PrintMessage(HUD_PRINTTALK,"Found more than one user with a discord tag like '"..tag.."'. Please specify!") end
+		if (res.answer == 0) then ply:PrintMessage(HUD_PRINTTALK,"["..GetConVar("discordbot_name"):GetString().."] ".."No guilde member with a discord tag like '"..tag.."' found.") end
+		if (res.answer == 1) then ply:PrintMessage(HUD_PRINTTALK,"["..GetConVar("discordbot_name"):GetString().."] ".."Found more than one user with a discord tag like '"..tag.."'. Please specify!") end
 		if (res.tag && res.id) then
-			ply:PrintMessage(HUD_PRINTTALK,"Discord tag '"..res.tag.."' successfully boundet to SteamID '"..ply:SteamID().."'") --lie! actually the discord id is bound! ;)
+			ply:PrintMessage(HUD_PRINTTALK,"["..GetConVar("discordbot_name"):GetString().."] ".."Discord tag '"..res.tag.."' successfully boundet to SteamID '"..ply:SteamID().."'") --lie! actually the discord id is bound! ;)
 			ids[ply:SteamID()] = res.id
 			saveIDs()
 		end
@@ -138,9 +140,9 @@ end)
 
 hook.Add("PlayerInitialSpawn", "ttt_discord_bot_PlayerInitialSpawn", function(ply)
 	if (ids[ply:SteamID()]) then
-		ply:PrintMessage(HUD_PRINTTALK,"You are connected with discord.")
+		ply:PrintMessage(HUD_PRINTTALK,"["..GetConVar("discordbot_name"):GetString().."] ".."You are connected with discord.")
 	else
-		ply:PrintMessage(HUD_PRINTTALK,"You are not connected with discord. Write '!discord DISCORDTAG' in the chat. E.g. '!discord marcel.js#4402'")
+		ply:PrintMessage(HUD_PRINTTALK,"["..GetConVar("discordbot_name"):GetString().."] ".."You are not connected with discord. Write '!discord DISCORDTAG' in the chat. E.g. '!discord marcel.js#4402'")
 	end
 end)
 


### PR DESCRIPTION
So apparently Gmod removed support for localhost in the latest patch and broke the bot AGAIN. (or it just doesn't work anymore for some bizzarre reason) and so I set some convars for users to set.

discordbot_host
discordbot_port
discordbot_name

...host sets the hostname
...port sets the port
...name sets the name of the plugin and log-infos

though it's important that users change the IP from localhost to an actual IP address or Hostname.

Also it is now possible to run the node script on a different server (like a pi or something).

Co-Authored-By: Flopsi99 <flopsi99@users.noreply.github.com>