### PR TITLE
Send a response for mute/unmute requests when the player is already in the requested state and add a timeout

### DIFF
--- a/discord_bot/index.js
+++ b/discord_bot/index.js
@@ -87,7 +87,7 @@ get['mute'] = (params,ret) => {
 					});
 				});
 			}
-			else if (member.serverMute && !mute) {
+			else if (member.serverMute && !mute && isMemberMutedByBot(member)) {
 				member.setMute(false).then(()=>{
 					setMemberMutedByBot(member,false);
 					ret({

--- a/discord_bot/index.js
+++ b/discord_bot/index.js
@@ -99,13 +99,13 @@ get['mute'] = (params,ret) => {
 						error: err
 					});
 				});
-            }
-            else {
-                // Already in requested state
-                ret({
+			}
+			else {
+				// Already in requested state
+				ret({
 					success: true,
 				});
-            }
+			}
 		}
 		else {
 			ret();

--- a/discord_bot/index.js
+++ b/discord_bot/index.js
@@ -87,7 +87,7 @@ get['mute'] = (params,ret) => {
 					});
 				});
 			}
-			if (member.serverMute && !mute) {
+			else if (member.serverMute && !mute) {
 				member.setMute(false).then(()=>{
 					setMemberMutedByBot(member,false);
 					ret({
@@ -99,7 +99,13 @@ get['mute'] = (params,ret) => {
 						error: err
 					});
 				});
-			}
+            }
+            else {
+                // Already in requested state
+                ret({
+					success: true,
+				});
+            }
 		}
 		else {
 			ret();
@@ -114,8 +120,7 @@ get['mute'] = (params,ret) => {
 
 }
 
-
-http.createServer((req,res)=>{
+var srvr = http.createServer((req,res)=>{
 	if (typeof req.headers.params === 'string' && typeof req.headers.req === 'string' && typeof get[req.headers.req] === 'function') {
 		try {
 			let params = JSON.parse(req.headers.params);
@@ -125,7 +130,10 @@ http.createServer((req,res)=>{
 		}
 	}else
 		res.end();
-}).listen({
+});
+
+srvr.timeout = 1000;
+srvr.listen({
 	port: PORT
 },()=>{
 	log('http interface is ready :)')


### PR DESCRIPTION
Should resolve issues with the server lagging/freezing -- as well as unmuting pre-emptively.

The pre-emptive unmuting problem occurs because unmute requests sent when the player is already unmuted (such as an unmute request at round start and then at playerspawn) retry constantly until the player can be unmuted (as in, as soon as the player gets muted again, the previous unmute request that failed finally goes through). This seems to be because gmod never receives a return response for mute requests in which the player is already in the correct state. This pull request sends a response in such cases.
  
I believe this was also the cause of the server lagging/freezing. In any case, the timeout should resolve that issue if it remains.

Fixes #11 